### PR TITLE
Removed mumbai polygon links on pfp

### DIFF
--- a/src/components/Profile/Header/Account.tsx
+++ b/src/components/Profile/Header/Account.tsx
@@ -52,19 +52,6 @@ export default function Account({
             {accountId} <Copy text={accountId} />
           </code>
         )}
-        <p>
-          {accountId &&
-            chainIds.map((value) => (
-              <ExplorerLink
-                className={styles.explorer}
-                networkId={value}
-                path={`address/${accountId}`}
-                key={value}
-              >
-                <NetworkName networkId={value} />
-              </ExplorerLink>
-            ))}
-        </p>
         {role && <span className={styles.tag}>{role}</span>}
       </div>
     </div>


### PR DESCRIPTION
Removed the links below the account addresses because it added too much complexity and information that users do not want or care to see. 