### PR TITLE
removed preview window from the preview feature

### DIFF
--- a/src/components/Publish/Preview/index.tsx
+++ b/src/components/Publish/Preview/index.tsx
@@ -43,7 +43,6 @@ export default function Preview(): ReactElement {
       <h2 className={styles.previewTitle}>Preview</h2>
 
       <h3 className={styles.assetTitle}>{values.metadata.name}</h3>
-      {asset && <AssetContent asset={asset} />}
     </div>
   )
 }


### PR DESCRIPTION
For error from #20 

Removed the preview window for now. Later, we can either remove the preview feature entirely or try to fix the TypeError. To remove the entire preview feature, we will need to look into the Navigate component.