### PR TITLE
Fixed styling/colors

### DIFF
--- a/src/components/Asset/AssetActions/Compute/assetAccess.tsx
+++ b/src/components/Asset/AssetActions/Compute/assetAccess.tsx
@@ -51,7 +51,7 @@ export default function AssetAccess(): ReactElement {
 
   return (
     <div>
-      <h3 className={styles.heading}>Grant Access</h3>
+      <h4 className={styles.heading}>Grant Access</h4>
 
       <form className={styles.searchBox}>
         <InputElement
@@ -105,7 +105,7 @@ export default function AssetAccess(): ReactElement {
       </div>
 
       <div>
-        <h3 className={styles.heading}>People Currently with Access</h3>
+        <h4 className={styles.heading}>People Currently with Access</h4>
       </div>
       <div className={styles.scroll}>
         {accessList &&

--- a/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
+++ b/src/components/Asset/AssetContent/IndividualUseVisualization.tsx
@@ -145,9 +145,8 @@ export default function IndividualUseVisualization({
   return (
     <div>
       <svg width={width} height={height}>
-        <LinearGradient id="stroke" from="#ffefef" to="#ffffff" />
         <rect
-          fill="url('#stroke')"
+          fill="#FFFFFF"
           strokeWidth={1}
           stroke="#e2e2e2"
           width="100%"

--- a/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
+++ b/src/components/Asset/AssetContent/TransactionHistoryVisualization.tsx
@@ -209,15 +209,15 @@ export default withTooltip<TimelineProps, Order>(
     return (
       <div>
         <svg width={width} height={height}>
-          <LinearGradient id="stroke" from="#ffefef" to="#ffffff" />
           <rect
-            fill="url('#stroke')"
+            fill="#FFFFFF"
             strokeWidth={1}
             stroke="#e2e2e2"
             width="100%"
             height="100%"
             rx={4}
           />
+
           {filteredOrders.map((order: Order, i) => {
             return (
               <Group top={height / 4} key={`filtered-dot-${i}`}>
@@ -235,12 +235,12 @@ export default withTooltip<TimelineProps, Order>(
                         ? 'pink'
                         : order.estimatedUSDValue === 'Granted'
                         ? 'lightgreen'
-                        : 'darkgreen'
+                        : '#00BB00'
                       : order.estimatedUSDValue === 'Denied'
                       ? '#e44c4c'
                       : order.estimatedUSDValue === 'Granted'
-                      ? 'darkgreen'
-                      : 'darkgreen'
+                      ? '#00BB00'
+                      : '#00BB00'
                   }
                   onMouseOver={() => {
                     const top = height - 110
@@ -270,12 +270,12 @@ export default withTooltip<TimelineProps, Order>(
                         ? 'pink'
                         : order.estimatedUSDValue === 'Granted'
                         ? 'lightgreen'
-                        : 'darkgreen'
+                        : '#00BB00'
                       : order.estimatedUSDValue === 'Denied'
                       ? '#e44c4c'
                       : order.estimatedUSDValue === 'Granted'
-                      ? 'darkgreen'
-                      : 'darkgreen'
+                      ? '#00BB00'
+                      : '#00BB00'
                   }
                   onMouseOver={() => {
                     const top = height - 110
@@ -314,9 +314,7 @@ export default withTooltip<TimelineProps, Order>(
                     order.estimatedUSDValue === 'Denied' ? '#990000' : '#004516'
                   }
                   fill={
-                    order.estimatedUSDValue === 'Denied'
-                      ? '#e44c4c'
-                      : 'darkgreen'
+                    order.estimatedUSDValue === 'Denied' ? '#e44c4c' : '#00BB00'
                   }
                 />
                 <text
@@ -406,7 +404,7 @@ export default withTooltip<TimelineProps, Order>(
                     color:
                       tooltipData.estimatedUSDValue === 'Denied'
                         ? 'red'
-                        : 'green'
+                        : '#00BB00'
                   }}
                 >{`${tooltipData.estimatedUSDValue}`}</strong>
               </div>


### PR DESCRIPTION
1. Changed the green circles to have a lighter green hue. Should show up more clearly as green on darker screens. 
2. Reduced the header size for some components within the asset access component. 
3. Replaced the gradient background on both visualizations with a solid white background.

Closes #69. Closes #67.